### PR TITLE
build: use official zerotier base image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,5 +54,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/386,linux/ppc64le,linux/s390x,linux/arm64,linux/arm/v6,linux/arm/v7,linux/riscv64
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/mips64le,linux/ppc64le,linux/s390x
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
         
       - name: Build this image for multi arch
-        run: docker buildx build -t seedgou/zerotier-moon:edge --platform=linux/amd64,linux/386,linux/ppc64le,linux/s390x,linux/arm64,linux/arm/v6,linux/arm/v7 .
+        run: docker buildx build -t seedgou/zerotier-moon:edge --platform=linux/386,linux/amd64,linux/arm/v7,linux/arm64,linux/mips64le,linux/ppc64le,linux/s390x .
       
       - name: Build this image
         run: docker build -t zerotier-moon .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-ARG ALPINE_VERSION=edge
+ARG ZT_VERSION=1.14.2
 
-FROM alpine:${ALPINE_VERSION}
-
-ARG ZT_VERSION=1.8.4-r0
+FROM zerotier/zerotier:${ZT_VERSION}
 
 LABEL maintainer="seedgou <seedgou@gmail.com>"
 
-RUN apk add --no-cache zerotier-one=${ZT_VERSION}
-
 COPY startup.sh /startup.sh
+RUN chmod +x /startup.sh
 EXPOSE 9993/udp
 
 ENTRYPOINT ["/startup.sh"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
     <img src="https://img.shields.io/docker/image-size/seedgou/zerotier-moon/latest" alt="Docker Image Size" />
 </a>
 <br>
-A docker image to create ZeroTier moon in one setp.
+A docker image to create a ZeroTier moon in one step.
+
+This image now inherits ZeroTier from the official [`zerotier/zerotier`](https://hub.docker.com/r/zerotier/zerotier/tags) base image instead of installing `zerotier-one` from Alpine packages.
 
 Have a look at dockerized ZeroTier: [rwv/zerotier](https://github.com/rwv/docker-zerotier).
 
@@ -92,7 +94,7 @@ docker exec zerotier-moon zerotier-cli
 docker run --name zerotier-moon -d -p 9993:9993/udp -v ~/somewhere:/var/lib/zerotier-one seedgou/zerotier-moon -4 1.2.3.4 
 ```
 
-When creating a new container without mounting ZeroTier conf folder, a new moon id will be generated. This command will mount `~/somewhere` to `/var/lib/zerotier-one` inside the container, allowing your ZeroTier moon to presist the same moon id. If you don't do this, when you start a new container, a new moon id will be generated.
+When creating a new container without mounting ZeroTier conf folder, a new moon id will be generated. This command will mount `~/somewhere` to `/var/lib/zerotier-one` inside the container, allowing your ZeroTier moon to persist the same moon id. If you don't do this, when you start a new container, a new moon id will be generated.
 
 ### IPv6 support
 
@@ -123,7 +125,7 @@ See Also [Issue #1](https://github.com/rwv/docker-zerotier-moon/issues/1).
 
 ### Multi-arch support
 
-This image supports `linux/386`, `linux/amd64`, `linux/ppc64le`, `linux/arm64`, `linux/arm/v7`, `linux/arm/v6`, `linux/s390x` and `linux/riscv64`.
+This image supports `linux/386`, `linux/amd64`, `linux/arm/v7`, `linux/arm64`, `linux/mips64le`, `linux/ppc64le`, and `linux/s390x`.
 
 ### GitHub Container Registry
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 
+set -eu
+
 # usage ./startup.sh -4 1.2.3.4 -6 2001:abcd:abcd::1 -p 9993
 
 moon_port=9993 # default ZeroTier moon port
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH}"
 
 while getopts "4:6:p:" arg # handle args
 do
@@ -26,10 +29,19 @@ do
         esac
 done
 
+zt_one_bin=$(command -v zerotier-one || true)
+zt_idtool_bin=$(command -v zerotier-idtool || true)
+
+if [ -z "$zt_one_bin" ] || [ -z "$zt_idtool_bin" ]
+then
+        echo "ZeroTier binaries not found in PATH."
+        exit 1
+fi
+
 stableEndpointsForSed=""
-if [ -z ${ipv4_address+x} ]
+if [ -z "${ipv4_address+x}" ]
 then # ipv4 address is not set
-        if [ -z ${ipv6_address+x} ]
+        if [ -z "${ipv6_address+x}" ]
         then # ipv6 address is not set
                 echo "Please set IPv4 address or IPv6 address."
                 exit 0
@@ -37,7 +49,7 @@ then # ipv4 address is not set
                 stableEndpointsForSed="\"$ipv6_address\/$moon_port\""
         fi
 else # ipv4 address is set
-        if [ -z ${ipv6_address+x} ]
+        if [ -z "${ipv6_address+x}" ]
         then # ipv6 address is not set
                 stableEndpointsForSed="\"$ipv4_address\/$moon_port\""
         else # ipv6 address is set
@@ -45,24 +57,31 @@ else # ipv4 address is set
         fi
 fi
 
+show_moon_id() {
+        moon_id="$1"
+        printf 'Your ZeroTier moon id is \033[0;31m%s\033[0m, you could orbit moon using \033[0;31m"zerotier-cli orbit %s %s"\033[0m\n' "$moon_id" "$moon_id" "$moon_id"
+}
+
 if [ -d "/var/lib/zerotier-one/moons.d" ] # check if the moons conf has generated
 then
         moon_id=$(cat /var/lib/zerotier-one/identity.public | cut -d ':' -f1)
-        echo -e "Your ZeroTier moon id is \033[0;31m$moon_id\033[0m, you could orbit moon using \033[0;31m\"zerotier-cli orbit $moon_id $moon_id\"\033[0m"
-        /usr/sbin/zerotier-one
+        show_moon_id "$moon_id"
+        exec "$zt_one_bin"
 else
-        nohup /usr/sbin/zerotier-one >/dev/null 2>&1 &
+        "$zt_one_bin" >/dev/null 2>&1 &
+        zt_pid=$!
         # Waiting for identity generation...'
         while [ ! -f /var/lib/zerotier-one/identity.secret ]; do
 	        sleep 1
         done
-        /usr/sbin/zerotier-idtool initmoon /var/lib/zerotier-one/identity.public >>/var/lib/zerotier-one/moon.json
+        "$zt_idtool_bin" initmoon /var/lib/zerotier-one/identity.public >/var/lib/zerotier-one/moon.json
         sed -i 's/"stableEndpoints": \[\]/"stableEndpoints": ['$stableEndpointsForSed']/g' /var/lib/zerotier-one/moon.json
-        /usr/sbin/zerotier-idtool genmoon /var/lib/zerotier-one/moon.json > /dev/null
-        mkdir /var/lib/zerotier-one/moons.d
+        "$zt_idtool_bin" genmoon /var/lib/zerotier-one/moon.json >/dev/null
+        mkdir -p /var/lib/zerotier-one/moons.d
         mv *.moon /var/lib/zerotier-one/moons.d/
-        pkill zerotier-one
+        kill "$zt_pid" 2>/dev/null || true
+        wait "$zt_pid" 2>/dev/null || true
         moon_id=$(cat /var/lib/zerotier-one/moon.json | grep \"id\" | cut -d '"' -f4)
-        echo -e "Your ZeroTier moon id is \033[0;31m$moon_id\033[0m, you could orbit moon using \033[0;31m\"zerotier-cli orbit $moon_id $moon_id\"\033[0m"
-        exec /usr/sbin/zerotier-one
+        show_moon_id "$moon_id"
+        exec "$zt_one_bin"
 fi


### PR DESCRIPTION
## Summary
- switch the image base from Alpine package install to `zerotier/zerotier:1.14.2`
- remove Alpine-specific assumptions from `startup.sh` and resolve ZeroTier binaries from `PATH`
- align CI and README platform lists with the upstream official image manifest

## Testing
- `sh -n startup.sh`
- `docker build -t zerotier-moon:test .`
- run the built image and verify `moon.json` is generated via `docker cp`