### PR TITLE
docs: refresh README and compose examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # docker-zerotier-moon
 
-<a href="https://github.com/rwv/docker-zerotier-moon/actions">
-    <img src="https://img.shields.io/github/workflow/status/rwv/docker-zerotier-moon/Docker" alt="GitHub Actions" />
-</a>
-<a href="https://hub.docker.com/r/seedgou/zerotier-moon">
-    <img src="https://img.shields.io/docker/v/seedgou/zerotier-moon?sort=semver" alt="Docker Version" />
-    <img src="https://img.shields.io/docker/pulls/seedgou/zerotier-moon" alt="Docker Hub" />
-    <img src="https://img.shields.io/docker/image-size/seedgou/zerotier-moon/latest" alt="Docker Image Size" />
-</a>
-<br>
+[![Docker](https://github.com/rwv/docker-zerotier-moon/actions/workflows/ci.yml/badge.svg)](https://github.com/rwv/docker-zerotier-moon/actions/workflows/ci.yml)
+[![Docker Version](https://img.shields.io/docker/v/seedgou/zerotier-moon?sort=semver)](https://hub.docker.com/r/seedgou/zerotier-moon)
+[![Docker Pulls](https://img.shields.io/docker/pulls/seedgou/zerotier-moon)](https://hub.docker.com/r/seedgou/zerotier-moon)
+[![Docker Image Size](https://img.shields.io/docker/image-size/seedgou/zerotier-moon/latest)](https://hub.docker.com/r/seedgou/zerotier-moon)
+
 A docker image to create a ZeroTier moon in one step.
 
 This image now inherits ZeroTier from the official [`zerotier/zerotier`](https://hub.docker.com/r/zerotier/zerotier/tags) base image instead of installing `zerotier-one` from Alpine packages.
@@ -18,11 +14,9 @@ Have a look at dockerized ZeroTier: [rwv/zerotier](https://github.com/rwv/docker
 ## Table of Contents
 
 - [Quickstart](#quickstart)
-  - [Start a container](#start-a-container)
+  - [Docker Run](#docker-run)
+  - [Docker Compose](#docker-compose)
   - [Show ZeroTier moon id](#show-zerotier-moon-id)
-- [Docker Compose](#docker-compose)
-  - [Compose file](#compose-file)
-  - [Show ZeroTier moon id](#show-zerotier-moon-id-1)
 - [Advanced usage](#advanced-usage)
   - [Manage ZeroTier](#manage-zerotier)
   - [Mount ZeroTier conf folder](#mount-zerotier-conf-folder)
@@ -34,94 +28,120 @@ Have a look at dockerized ZeroTier: [rwv/zerotier](https://github.com/rwv/docker
 
 ## Quickstart
 
-### Start a container
+### Docker Run
 
-```
-docker run --name zerotier-moon -d --restart always -p 9993:9993/udp -v ~/somewhere:/var/lib/zerotier-one seedgou/zerotier-moon -4 1.2.3.4
-```
-
-Replace `1.2.3.4` with your moon's IPv4 address and replace `~/somewhere` with where you would like to store your configuration.
-
-### Show ZeroTier moon id
-
-```
-docker logs zerotier-moon
+```bash
+docker run --name zerotier-moon -d --restart always \
+  -p 9993:9993/udp \
+  -v ~/somewhere:/var/lib/zerotier-one \
+  seedgou/zerotier-moon:latest \
+  -4 1.2.3.4
 ```
 
-## Docker Compose
+Replace `1.2.3.4` with your moon's IPv4 address and replace `~/somewhere` with where you would like to store ZeroTier state.
 
-### Compose file
+### Docker Compose
 
-`docker-compose.yml` example:
+`compose.yml` example:
 
-``` YAML
-version: "3"
-
+```yaml
 services:
   zerotier-moon:
-    image: seedgou/zerotier-moon
-    container_name: "zerotier-moon"
-    restart: always
+    image: seedgou/zerotier-moon:latest
+    container_name: zerotier-moon
+    restart: unless-stopped
     ports:
       - "9993:9993/udp"
     volumes:
       - ./config:/var/lib/zerotier-one
-    entrypoint:
-      - /startup.sh
+    command:
       - "-4"
-      - 1.2.3.4
+      - "1.2.3.4"
+      - "-p"
+      - "9993"
 ```
 
-Replace `1.2.3.4` with your moon's IPv4 address.
+Replace `1.2.3.4` with your public IPv4 address and adjust `./config`, image, or port mapping if needed.
+
+Then start the container:
+
+```bash
+docker compose up -d
+```
 
 ### Show ZeroTier moon id
 
-``` bash
-docker-compose logs
+```bash
+docker logs zerotier-moon
+```
+
+Or, if you started it with Docker Compose:
+
+```bash
+docker compose logs -f zerotier-moon
 ```
 
 ## Advanced usage
 
 ### Manage ZeroTier
 
-```
+```bash
 docker exec zerotier-moon zerotier-cli
 ```
 
 ### Mount ZeroTier conf folder
 
-```
-docker run --name zerotier-moon -d -p 9993:9993/udp -v ~/somewhere:/var/lib/zerotier-one seedgou/zerotier-moon -4 1.2.3.4 
+```bash
+docker run --name zerotier-moon -d \
+  -p 9993:9993/udp \
+  -v ~/somewhere:/var/lib/zerotier-one \
+  seedgou/zerotier-moon:latest \
+  -4 1.2.3.4
 ```
 
 When creating a new container without mounting ZeroTier conf folder, a new moon id will be generated. This command will mount `~/somewhere` to `/var/lib/zerotier-one` inside the container, allowing your ZeroTier moon to persist the same moon id. If you don't do this, when you start a new container, a new moon id will be generated.
 
 ### IPv6 support
 
-```
-docker run --name zerotier-moon -d -p 9993:9993/udp seedgou/zerotier-moon -4 1.2.3.4 -6 2001:abcd:abcd::1
+```bash
+docker run --name zerotier-moon -d \
+  -p 9993:9993/udp \
+  seedgou/zerotier-moon:latest \
+  -4 1.2.3.4 \
+  -6 2001:abcd:abcd::1
 ```
 
 Replace `1.2.3.4`, `2001:abcd:abcd::1` with your moon's IP. You can remove `-4` option in pure IPv6 environment.
+For Docker Compose, add `- "-6"` and your IPv6 address under `command` in the example above.
 
 ### Custom port
 
-```
-docker run --name zerotier-moon -d -p 9994:9993/udp seedgou/zerotier-moon -4 1.2.3.4 -p 9994
+```bash
+docker run --name zerotier-moon -d \
+  -p 9994:9993/udp \
+  seedgou/zerotier-moon:latest \
+  -4 1.2.3.4 \
+  -p 9994
 ```
 
 Replace 9994 with your own custom port for ZeroTier moon.
+If you use Docker Compose, update both the published port and the `-p` value in `command`.
 
 ### Network privilege
 
 If you encounter issue: `ERROR: unable to configure virtual network port: could not open TUN/TAP device: No such file or directory`, please add `--cap-add=NET_ADMIN --cap-add=SYS_ADMIN --device=/dev/net/tun` args. Similar to this:
 
-```
-docker run --cap-add=NET_ADMIN --cap-add=SYS_ADMIN --device=/dev/net/tun --name zerotier-moon -d --restart always -p 9993:9993/udp seedgou/zerotier-moon -4 1.2.3.4
+```bash
+docker run --cap-add=NET_ADMIN --cap-add=SYS_ADMIN --device=/dev/net/tun \
+  --name zerotier-moon -d --restart always \
+  -p 9993:9993/udp \
+  seedgou/zerotier-moon:latest \
+  -4 1.2.3.4
 ```
 
 Solution provided by [Jonnyan404's Fork](https://github.com/Jonnyan404/docker-zerotier-moon).
 See Also [Issue #1](https://github.com/rwv/docker-zerotier-moon/issues/1).
+If you use Docker Compose, add `cap_add` and `devices` to the service definition when your host requires TUN/TAP access.
 
 ### Multi-arch support
 
@@ -130,3 +150,5 @@ This image supports `linux/386`, `linux/amd64`, `linux/arm/v7`, `linux/arm64`, `
 ### GitHub Container Registry
 
 This image is also published on GitHub Container Registry: [`ghcr.io/rwv/zerotier-moon`](https://ghcr.io/rwv/zerotier-moon)
+
+To use it with Docker Compose, replace `image: seedgou/zerotier-moon:latest` with `image: ghcr.io/rwv/zerotier-moon:latest`.


### PR DESCRIPTION
## Summary
- replace the broken Actions badge with the GitHub workflow badge for `ci.yml`
- add a checked-in `compose.yml` and `.env.example` instead of only documenting an inline Compose snippet
- refresh README commands and links to match the current workflow and published images

## Validation
- `docker compose --env-file .env.example -f compose.yml config`
- `curl -I -L https://github.com/rwv/docker-zerotier-moon/actions/workflows/ci.yml/badge.svg?branch=master&event=push` returned `200`