### PR TITLE
ci: publish latest only on release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
             ${{ env.DOCKERHUB_IMAGE }}
             ${{ env.GHCR_IMAGE }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha


### PR DESCRIPTION
## Summary
- stop generating the `latest` image tag on every push to `master`
- keep publishing on `master`, but only expose release-oriented tags from semver tag events
- rely on `docker/metadata-action` semver tagging so `latest` is produced on release tags instead of branch pushes

## Validation
- parsed `.github/workflows/ci.yml` as YAML
- reviewed the workflow diff to confirm this only removes the branch-scoped `latest` tag rule