### PR TITLE
build: remove redundant chmod step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ FROM zerotier/zerotier:${ZT_VERSION}
 LABEL maintainer="seedgou <seedgou@gmail.com>"
 
 COPY startup.sh /startup.sh
-RUN chmod +x /startup.sh
 EXPOSE 9993/udp
 
 ENTRYPOINT ["/startup.sh"]


### PR DESCRIPTION
## Summary
- remove the redundant `RUN chmod +x /startup.sh` layer from the Dockerfile
- rely on the executable bit already tracked for `startup.sh` in Git

## Validation
- `git ls-files --stage startup.sh` shows mode `100755`
- `docker build -t zerotier-moon:test .`